### PR TITLE
Improve error handling when create-project fails

### DIFF
--- a/src/ImboLauncher/Server.php
+++ b/src/ImboLauncher/Server.php
@@ -221,8 +221,8 @@ class Server {
         // Command used to create the project using composer
         $command = sprintf(
             'composer create-project -n imbo/imbo %s %s',
-            $this->getInstallPath(),
-            $this->version
+            escapeshellarg($this->getInstallPath()),
+            escapeshellarg($this->version)
         );
         $this->shout(sprintf('Executing command: %s', $command));
         exec($command);
@@ -230,8 +230,8 @@ class Server {
         // Create a link to the configuration file
         $command = sprintf(
             'ln -s %s %s',
-            $this->config,
-            $this->getInstallPath() . '/config/config.php'
+            escapeshellarg($this->config),
+            escapeshellarg($this->getInstallPath() . '/config/config.php')
         );
         $this->shout(sprintf('Executing command: %s', $command));
         exec($command);
@@ -248,10 +248,10 @@ class Server {
         // Start the server
         $command = sprintf(
             'php -S %s:%d -t %s %s >/dev/null 2>&1 & echo $!',
-            $this->host,
+            escapeshellarg($this->host),
             $this->port,
-            $this->getInstallPath() . '/public',
-            self::$router);
+            escapeshellarg($this->getInstallPath() . '/public'),
+            escapeshellarg(self::$router));
 
         $this->shout(sprintf('Executing command: %s', $command));
         $output = array();

--- a/src/ImboLauncher/Server.php
+++ b/src/ImboLauncher/Server.php
@@ -234,7 +234,14 @@ class Server {
             escapeshellarg($this->version)
         );
         $this->shout(sprintf('Executing command: %s', $command));
-        exec($command);
+        exec($command, $output, $returnVal);
+
+        if ($returnVal > 0) {
+            throw new RuntimeException(sprintf(
+                'Could not install server (%s), aborting',
+                $this->version
+            ));
+        }
 
         // Create a link to the configuration file
         $command = sprintf(

--- a/src/ImboLauncher/Server.php
+++ b/src/ImboLauncher/Server.php
@@ -171,6 +171,15 @@ class Server {
     }
 
     /**
+     * Get the path for the logfile
+     *
+     * @return string
+     */
+    private function getLogPath() {
+        return $this->getInstallPath() . '/httpd.log';
+    }
+
+    /**
      * Shout a message
      *
      * @param string $message
@@ -247,11 +256,12 @@ class Server {
 
         // Start the server
         $command = sprintf(
-            'php -S %s:%d -t %s %s >/dev/null 2>&1 & echo $!',
+            'php -S %s:%d -t %s %s >%s 2>&1 & echo $!',
             escapeshellarg($this->host),
             $this->port,
             escapeshellarg($this->getInstallPath() . '/public'),
-            escapeshellarg(self::$router));
+            escapeshellarg(self::$router),
+            escapeshellarg($this->getLogPath()));
 
         $this->shout(sprintf('Executing command: %s', $command));
         $output = array();


### PR DESCRIPTION
This PR:
- Makes imbolauncher exit early if `composer create-project` fails.
- Logs httpd output to `httpd.log` within each version folder for easier debugging (fixes #2)
- Adds some escaping of shell arguments (in case anyone wants to put `| rm -rf ~` as their installation path

Sorry about not creating separate PRs for these changes.
