### PR TITLE
Print version and commit/revision of imbo when installing

### DIFF
--- a/src/ImboLauncher/Server.php
+++ b/src/ImboLauncher/Server.php
@@ -250,6 +250,15 @@ class Server {
             ));
         }
 
+        // Get the version and commit from the output
+        $installedVersion = preg_replace(
+            '/.*Installing imbo\/imbo \((.*?)\).*/s',
+            '$1',
+            implode("\n", $output)
+        );
+
+        $this->say(sprintf('Installed imbo/imbo @ %s', $installedVersion));
+
         // Create a link to the configuration file
         $command = sprintf(
             'ln -s %s %s',


### PR DESCRIPTION
When using imbolauncher in a continuous integration setting, it can sometimes be very helpful to know which revision of imbo was actually installed (when running against dev-develop) - especially when comparing against historical runs, to see if the release of the server has actually changed.

This PR extracts the version and revision from the composer output and outputs it when the server is successfully installed.
