### PR TITLE
Add __DIR__ to fix not launched as bin/imbolauncher

### DIFF
--- a/bin/imbolauncher
+++ b/bin/imbolauncher
@@ -11,11 +11,21 @@
 
 $parent = __DIR__;
 
-while (($parent = dirname($parent)) !== '/') {
+$previousParent = null;
+
+while (($parent = dirname($parent)) != $previousParent) {
     if (file_exists($parent . "/vendor/autoload.php")) {
         break;
     }
+    
+    $previousParent = $parent;
 }
+
+if ($previousParent == $parent) {
+    exit("Could not find a suitable vendor/ directory in any parent directories.\n\nInstall dependencies by running\n\n    composer install\n\nin the main imbolauncher directory.\n");
+}
+
+print($parent . "/vendor/autoload.php");
 
 require $parent . '/vendor/autoload.php';
 

--- a/bin/imbolauncher
+++ b/bin/imbolauncher
@@ -22,7 +22,7 @@ while (($parent = dirname($parent)) != $previousParent) {
 }
 
 if ($previousParent == $parent) {
-    exit("Could not find a suitable vendor/ directory in any parent directories.\n\nInstall dependencies by running\n\n    composer install\n\nin the main imbolauncher directory.\n");
+    exit("Could not find a suitable vendor/ directory in any parent directories.\n\nInstall dependencies by running\n\n    composer install --no-dev\n\nin the main imbolauncher directory.\n");
 }
 
 print($parent . "/vendor/autoload.php");

--- a/bin/imbolauncher
+++ b/bin/imbolauncher
@@ -9,7 +9,7 @@
  * distributed with this source code.
  */
 
-require 'vendor/autoload.php';
+require __DIR__ . '/../vendor/autoload.php';
 
 $app = new ImboLauncher\Application();
 $app->run();

--- a/bin/imbolauncher
+++ b/bin/imbolauncher
@@ -9,7 +9,15 @@
  * distributed with this source code.
  */
 
-require __DIR__ . '/../vendor/autoload.php';
+$parent = __DIR__;
+
+while (($parent = dirname($parent)) !== '/') {
+    if (file_exists($parent . "/vendor/autoload.php")) {
+        break;
+    }
+}
+
+require $parent . '/vendor/autoload.php';
 
 $app = new ImboLauncher\Application();
 $app->run();


### PR DESCRIPTION
If imbolauncher is invoked outside of its own homedir (for example through an absolute path or inside the `bin` directory itself), the existing require will fail - as it uses a relative import from the CWD.