### PR TITLE
Replace deprecated "dialog" helper with new "question"

### DIFF
--- a/src/Command/KillServers.php
+++ b/src/Command/KillServers.php
@@ -14,6 +14,7 @@ use Symfony\Component\Console\Command\Command,
     Symfony\Component\Console\Input\InputInterface,
     Symfony\Component\Console\Input\InputOption,
     Symfony\Component\Console\Output\OutputInterface,
+    Symfony\Component\Console\Question\ConfirmationQuestion,
     RuntimeException,
     InvalidArgumentException;
 
@@ -91,7 +92,7 @@ class KillServers extends Command {
             ));
         }
 
-        $dialog = $this->getHelperSet()->get('dialog');
+        $helper = $this->getHelperSet()->get('question');
 
         $question = 'You are about to kill the following processes:' . PHP_EOL . PHP_EOL;
 
@@ -99,11 +100,12 @@ class KillServers extends Command {
             $question .= sprintf('%d: %s', $pid, $command) . PHP_EOL;
         }
 
-        $question .= PHP_EOL . 'Continue? [Yn]';
+        $question .= PHP_EOL . 'Continue? [Yn] ';
+        $confirmation = new ConfirmationQuestion($question, true);
 
         if (
             !$input->getOption('no-interaction') &&
-            !$dialog->askConfirmation($output, $question, true)
+            !$helper->ask($input, $output, $confirmation)
         ) {
             return;
         }

--- a/src/Command/StartServers.php
+++ b/src/Command/StartServers.php
@@ -15,6 +15,7 @@ use ImboLauncher\Server,
     Symfony\Component\Console\Input\InputInterface,
     Symfony\Component\Console\Output\OutputInterface,
     Symfony\Component\Console\Input\InputOption,
+    Symfony\Component\Console\Question\ConfirmationQuestion,
     RuntimeException,
     InvalidArgumentException,
     stdClass,
@@ -158,11 +159,12 @@ HELP;
 
         // Empty the install path if it contains any files
         if (count(glob($absoluteInstallPath . '/*'))) {
-            $dialog = $this->getHelperSet()->get('dialog');
+            $helper = $this->getHelperSet()->get('question');
+            $question = new ConfirmationQuestion($absoluteInstallPath . ' contains files and/or directories. Remove? [Yn] ', true);	
 
             if (
                 !$input->getOption('no-interaction') &&
-                !$dialog->askConfirmation($output, $absoluteInstallPath . ' contains files and/or directories. Remove? [Yn]', true)
+                !$helper->ask($input, $output, $question)
             ) {
                 throw new RuntimeException('ImboLauncher requires the installation path to be empty. Aborting...');
             }


### PR DESCRIPTION
The 'dialog' helper was deprecated in Symfony 2.5 and removed in 3.0. The question helper is its replacement.